### PR TITLE
adds chemmaster transfer amounts for 30 and 90 units

### DIFF
--- a/tgui/src/interfaces/chem_master.ract
+++ b/tgui/src/interfaces/chem_master.ract
@@ -15,6 +15,8 @@
 							<ui-button action='transferToBuffer' params='{"id": "{{id}}", "amount": 1}'>1</ui-button>
 							<ui-button action='transferToBuffer' params='{"id": "{{id}}", "amount": 5}'>5</ui-button>
 							<ui-button action='transferToBuffer' params='{"id": "{{id}}", "amount": 10}'>10</ui-button>
+							<ui-button action='transferToBuffer' params='{"id": "{{id}}", "amount": 30}'>30</ui-button>
+							<ui-button action='transferToBuffer' params='{"id": "{{id}}", "amount": 90}'>90</ui-button>
 							<ui-button action='transferToBuffer' params='{"id": "{{id}}", "amount": 1000}'>All</ui-button>
 							<ui-button action='transferToBuffer' params='{"id": "{{id}}", "amount": -1}'>Custom</ui-button>
 							<ui-button action='analyze' params='{"id": "{{id}}"}'>Analyze</ui-button>
@@ -39,6 +41,8 @@
 						<ui-button action='transferFromBuffer' params='{"id": "{{id}}", "amount": 1}'>1</ui-button>
 						<ui-button action='transferFromBuffer' params='{"id": "{{id}}", "amount": 5}'>5</ui-button>
 						<ui-button action='transferFromBuffer' params='{"id": "{{id}}", "amount": 10}'>10</ui-button>
+						<ui-button action='transferToBuffer' params='{"id": "{{id}}", "amount": 30}'>30</ui-button>
+						<ui-button action='transferToBuffer' params='{"id": "{{id}}", "amount": 90}'>90</ui-button>
 						<ui-button action='transferFromBuffer' params='{"id": "{{id}}", "amount": 1000}'>All</ui-button>
 						<ui-button action='transferFromBuffer' params='{"id": "{{id}}", "amount": -1}'>Custom</ui-button>
 						<ui-button action='analyze' params='{"id": "{{id}}"}'>Analyze</ui-button>


### PR DESCRIPTION
allows the chemmaster to transfer two additional amounts:
90 units - the amount that fits into 3 bottles. A large beaker is 100 units so if you hit "transfer all" then "transfer to bottles" you either have to add 10 units back into the beaker or you end up with a 1/3 full bottle. Saves a click
30 units - one bottle. Useful if you have a mix of things and don't want to click "10" three times